### PR TITLE
Dynamic Home Working Directory

### DIFF
--- a/lcmap_tap/__init__.py
+++ b/lcmap_tap/__init__.py
@@ -1,10 +1,16 @@
-
 import os
+from pathlib import Path
 
 # Get the path to the home directory for the current user and create an 'lcmap_tap' subfolder
-HOME = os.path.join('K:\90daytemp', r'TAP_Tool_files')
+HOME_BASE_DIR = str(Path.home())
+
+if HOME_BASE_DIR.startswith("C:"):
+    # If this is a local Windows file system, use the Documents directory
+    HOME = os.path.join(HOME_BASE_DIR, r"Documents", r"TAP_Tool_files")
+else:
+    HOME = os.path.join(HOME_BASE_DIR, r"TAP_Tool_files")
 
 if not os.path.exists(HOME):
     os.makedirs(HOME)
 
-__version__ = '1.2.0'
+__version__ = "1.2.1"

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ from setuptools import setup, find_packages
 setup(
     name='lcmap_tap',
 
-    version='1.2.0',
+    version='1.2.1',
 
     packages=find_packages(),
 


### PR DESCRIPTION
Set the working directory from a user's home environmental variable provided by the OS.

This prevents a hard coded network mapped drive situation.